### PR TITLE
fix: /api/alerts/rules 500 에러 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY core ./core
 COPY infra ./infra
 COPY api-app ./api-app
 COPY batch ./batch
-RUN gradle :api-app:bootJar --no-daemon -x test && \
+RUN gradle :api-app:bootJar --no-daemon && \
     rm -f /app/api-app/build/libs/*-plain.jar
 
 # ---- Runtime Stage ----

--- a/api-app/src/main/kotlin/com/econdashboard/controller/AlertController.kt
+++ b/api-app/src/main/kotlin/com/econdashboard/controller/AlertController.kt
@@ -4,6 +4,7 @@ import com.econdashboard.common.ApiResponse
 import com.econdashboard.dto.AlertHistoryResponse
 import com.econdashboard.dto.AlertRuleRequest
 import com.econdashboard.dto.AlertRuleResponse
+import com.econdashboard.dto.AlertRuleUpdateRequest
 import com.econdashboard.service.AlertService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
@@ -21,6 +22,12 @@ import org.springframework.web.bind.annotation.*
 class AlertController(
     private val alertService: AlertService
 ) {
+    @Operation(summary = "알림 규칙 목록 조회")
+    @GetMapping("/rules")
+    fun getAlertRules(): ApiResponse<List<AlertRuleResponse>> {
+        return ApiResponse.success(alertService.getAlertRules())
+    }
+
     @Operation(summary = "알림 규칙 생성")
     @PostMapping("/rules")
     @ResponseStatus(HttpStatus.CREATED)
@@ -28,6 +35,22 @@ class AlertController(
         @Valid @RequestBody request: AlertRuleRequest
     ): ApiResponse<AlertRuleResponse> {
         return ApiResponse.success(alertService.createAlertRule(request))
+    }
+
+    @Operation(summary = "알림 규칙 수정")
+    @PutMapping("/rules/{id}")
+    fun updateAlertRule(
+        @PathVariable id: Long,
+        @RequestBody request: AlertRuleUpdateRequest
+    ): ApiResponse<AlertRuleResponse> {
+        return ApiResponse.success(alertService.updateAlertRule(id, request))
+    }
+
+    @Operation(summary = "알림 규칙 삭제")
+    @DeleteMapping("/rules/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun deleteAlertRule(@PathVariable id: Long) {
+        alertService.deleteAlertRule(id)
     }
 
     @Operation(summary = "알림 이력 조회")

--- a/api-app/src/test/kotlin/com/econdashboard/controller/AlertControllerTest.kt
+++ b/api-app/src/test/kotlin/com/econdashboard/controller/AlertControllerTest.kt
@@ -1,0 +1,94 @@
+package com.econdashboard.controller
+
+import com.econdashboard.dto.AlertHistoryResponse
+import com.econdashboard.dto.AlertRuleResponse
+import com.econdashboard.enums.AlertConditionType
+import com.econdashboard.exception.GlobalExceptionHandler
+import com.econdashboard.exception.NotFoundException
+import com.econdashboard.service.AlertService
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.every
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.data.domain.PageImpl
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.post
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+@WebMvcTest(AlertController::class)
+class AlertControllerTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockkBean
+    private lateinit var alertService: AlertService
+
+    private val now = LocalDateTime.of(2025, 6, 1, 12, 0, 0)
+
+    @Test
+    fun `POST alert rule - 정상 생성`() {
+        val response = AlertRuleResponse(
+            id = 1L,
+            userId = "user1",
+            indicatorId = 1L,
+            indicatorName = "비트코인",
+            conditionType = AlertConditionType.ABOVE,
+            threshold = BigDecimal("70000"),
+            enabled = true,
+            createdAt = now,
+            updatedAt = now
+        )
+        every { alertService.createAlertRule(any()) } returns response
+
+        mockMvc.post("/api/alerts/rules") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"userId":"user1","indicatorId":1,"conditionType":"ABOVE","threshold":70000}"""
+        }.andExpect {
+            status { isCreated() }
+            jsonPath("$.data.userId") { value("user1") }
+            jsonPath("$.data.conditionType") { value("ABOVE") }
+        }
+    }
+
+    @Test
+    fun `POST alert rule - 존재하지 않는 지표`() {
+        every { alertService.createAlertRule(any()) } throws NotFoundException("Indicator", 999L)
+
+        mockMvc.post("/api/alerts/rules") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"userId":"user1","indicatorId":999,"conditionType":"ABOVE","threshold":70000}"""
+        }.andExpect {
+            status { isNotFound() }
+            jsonPath("$.error.code") { value("NOT_FOUND") }
+        }
+    }
+
+    @Test
+    fun `GET alert history - 사용자별 이력`() {
+        val history = AlertHistoryResponse(
+            id = 1L,
+            userId = "user1",
+            indicatorId = 1L,
+            indicatorName = "비트코인",
+            alertRuleId = 1L,
+            conditionType = AlertConditionType.ABOVE,
+            threshold = BigDecimal("70000"),
+            actualValue = BigDecimal("71000"),
+            message = "비트코인이(가) 70000 이상에 도달했습니다.",
+            createdAt = now
+        )
+        every { alertService.getAlertHistory("user1", any()) } returns PageImpl(listOf(history))
+
+        mockMvc.get("/api/alerts?userId=user1")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.data.content[0].userId") { value("user1") }
+                jsonPath("$.data.content[0].actualValue") { value(71000) }
+            }
+    }
+}

--- a/api-app/src/test/kotlin/com/econdashboard/controller/AlertControllerTest.kt
+++ b/api-app/src/test/kotlin/com/econdashboard/controller/AlertControllerTest.kt
@@ -33,25 +33,25 @@ class AlertControllerTest {
     @Test
     fun `POST alert rule - 정상 생성`() {
         val response = AlertRuleResponse(
-            id = 1L,
-            userId = "user1",
+            id = "1",
             indicatorId = 1L,
             indicatorName = "비트코인",
-            conditionType = AlertConditionType.ABOVE,
+            condition = "above",
             threshold = BigDecimal("70000"),
+            severity = "warning",
+            message = "",
             enabled = true,
-            createdAt = now,
-            updatedAt = now
+            createdAt = now.toString(),
+            updatedAt = now.toString()
         )
         every { alertService.createAlertRule(any()) } returns response
 
         mockMvc.post("/api/alerts/rules") {
             contentType = MediaType.APPLICATION_JSON
-            content = """{"userId":"user1","indicatorId":1,"conditionType":"ABOVE","threshold":70000}"""
+            content = """{"userId":"user1","indicatorId":1,"condition":"above","threshold":70000}"""
         }.andExpect {
             status { isCreated() }
-            jsonPath("$.data.userId") { value("user1") }
-            jsonPath("$.data.conditionType") { value("ABOVE") }
+            jsonPath("$.data.condition") { value("above") }
         }
     }
 
@@ -61,11 +61,35 @@ class AlertControllerTest {
 
         mockMvc.post("/api/alerts/rules") {
             contentType = MediaType.APPLICATION_JSON
-            content = """{"userId":"user1","indicatorId":999,"conditionType":"ABOVE","threshold":70000}"""
+            content = """{"userId":"user1","indicatorId":999,"condition":"above","threshold":70000}"""
         }.andExpect {
             status { isNotFound() }
             jsonPath("$.error.code") { value("NOT_FOUND") }
         }
+    }
+
+    @Test
+    fun `GET alert rules - 규칙 목록 조회`() {
+        val response = AlertRuleResponse(
+            id = "1",
+            indicatorId = 1L,
+            indicatorName = "비트코인",
+            condition = "above",
+            threshold = BigDecimal("70000"),
+            severity = "warning",
+            message = "",
+            enabled = true,
+            createdAt = now.toString(),
+            updatedAt = now.toString()
+        )
+        every { alertService.getAlertRules() } returns listOf(response)
+
+        mockMvc.get("/api/alerts/rules")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.data[0].id") { value("1") }
+                jsonPath("$.data[0].condition") { value("above") }
+            }
     }
 
     @Test

--- a/api-app/src/test/kotlin/com/econdashboard/controller/DashboardControllerTest.kt
+++ b/api-app/src/test/kotlin/com/econdashboard/controller/DashboardControllerTest.kt
@@ -1,0 +1,123 @@
+package com.econdashboard.controller
+
+import com.econdashboard.dto.DashboardWidgetResponse
+import com.econdashboard.enums.ChartType
+import com.econdashboard.exception.GlobalExceptionHandler
+import com.econdashboard.exception.NotFoundException
+import com.econdashboard.service.DashboardService
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.every
+import io.mockk.just
+import io.mockk.runs
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.delete
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.post
+import org.springframework.test.web.servlet.put
+import java.time.LocalDateTime
+
+@WebMvcTest(DashboardController::class)
+class DashboardControllerTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @MockkBean
+    private lateinit var dashboardService: DashboardService
+
+    private val now = LocalDateTime.of(2025, 6, 1, 12, 0, 0)
+
+    private fun sampleWidgetResponse(id: Long = 1L) = DashboardWidgetResponse(
+        id = id,
+        title = "주가지수",
+        chartType = ChartType.LINE,
+        positionX = 0,
+        positionY = 0,
+        width = 2,
+        height = 1,
+        config = null,
+        indicatorId = 1L,
+        createdAt = now,
+        updatedAt = now
+    )
+
+    @Test
+    fun `GET widgets - 위젯 목록 조회`() {
+        every { dashboardService.getAllWidgets() } returns listOf(sampleWidgetResponse())
+
+        mockMvc.get("/api/dashboard/widgets")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.success") { value(true) }
+                jsonPath("$.data[0].title") { value("주가지수") }
+                jsonPath("$.data[0].chartType") { value("LINE") }
+            }
+    }
+
+    @Test
+    fun `POST widgets - 일괄 저장`() {
+        every { dashboardService.saveWidgets(any()) } returns listOf(sampleWidgetResponse())
+
+        mockMvc.post("/api/dashboard/widgets") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """[{"title":"주가지수","chartType":"LINE","positionX":0,"positionY":0,"width":2,"height":1,"indicatorId":1}]"""
+        }.andExpect {
+            status { isCreated() }
+            jsonPath("$.data[0].title") { value("주가지수") }
+        }
+    }
+
+    @Test
+    fun `PUT widget - 수정`() {
+        every { dashboardService.updateWidget(1L, any()) } returns sampleWidgetResponse().copy(title = "수정됨")
+
+        mockMvc.put("/api/dashboard/widgets/1") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"title":"수정됨","chartType":"LINE","positionX":0,"positionY":0,"width":2,"height":1}"""
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.data.title") { value("수정됨") }
+        }
+    }
+
+    @Test
+    fun `PUT widget - 미존재시 404`() {
+        every { dashboardService.updateWidget(999L, any()) } throws NotFoundException("DashboardWidget", 999L)
+
+        mockMvc.put("/api/dashboard/widgets/999") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"title":"test","chartType":"LINE","positionX":0,"positionY":0}"""
+        }.andExpect {
+            status { isNotFound() }
+            jsonPath("$.error.code") { value("NOT_FOUND") }
+        }
+    }
+
+    @Test
+    fun `DELETE widget - 삭제`() {
+        every { dashboardService.deleteWidget(1L) } just runs
+
+        mockMvc.delete("/api/dashboard/widgets/1")
+            .andExpect {
+                status { isNoContent() }
+            }
+    }
+
+    @Test
+    fun `DELETE widget - 미존재시 404`() {
+        every { dashboardService.deleteWidget(999L) } throws NotFoundException("DashboardWidget", 999L)
+
+        mockMvc.delete("/api/dashboard/widgets/999")
+            .andExpect {
+                status { isNotFound() }
+            }
+    }
+}

--- a/api-app/src/test/kotlin/com/econdashboard/controller/IndicatorControllerTest.kt
+++ b/api-app/src/test/kotlin/com/econdashboard/controller/IndicatorControllerTest.kt
@@ -1,0 +1,150 @@
+package com.econdashboard.controller
+
+import com.econdashboard.dto.IndicatorDataResponse
+import com.econdashboard.dto.IndicatorResponse
+import com.econdashboard.dto.IndicatorSeriesResponse
+import com.econdashboard.enums.DataSource
+import com.econdashboard.enums.IndicatorCategory
+import com.econdashboard.exception.GlobalExceptionHandler
+import com.econdashboard.exception.NotFoundException
+import com.econdashboard.service.IndicatorService
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.every
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.post
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@WebMvcTest(IndicatorController::class)
+class IndicatorControllerTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @MockkBean
+    private lateinit var indicatorService: IndicatorService
+
+    private val now = LocalDateTime.of(2025, 6, 1, 12, 0, 0)
+
+    private fun sampleIndicatorResponse(id: Long = 1L) = IndicatorResponse(
+        id = id,
+        name = "S&P 500",
+        symbol = "SPX",
+        category = IndicatorCategory.STOCK,
+        unit = "포인트",
+        source = DataSource.YAHOO,
+        description = "미국 대표 주가지수",
+        createdAt = now,
+        updatedAt = now
+    )
+
+    @Test
+    fun `GET indicators - 전체 조회`() {
+        every { indicatorService.getAllIndicators(null) } returns listOf(sampleIndicatorResponse())
+
+        mockMvc.get("/api/indicators")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.success") { value(true) }
+                jsonPath("$.data[0].name") { value("S&P 500") }
+                jsonPath("$.data[0].symbol") { value("SPX") }
+            }
+    }
+
+    @Test
+    fun `GET indicators - 카테고리 필터`() {
+        every { indicatorService.getAllIndicators(IndicatorCategory.STOCK) } returns listOf(sampleIndicatorResponse())
+
+        mockMvc.get("/api/indicators?category=STOCK")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.data.length()") { value(1) }
+            }
+    }
+
+    @Test
+    fun `GET indicator by id - 정상`() {
+        every { indicatorService.getIndicatorById(1L) } returns sampleIndicatorResponse()
+
+        mockMvc.get("/api/indicators/1")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.data.id") { value(1) }
+                jsonPath("$.data.name") { value("S&P 500") }
+            }
+    }
+
+    @Test
+    fun `GET indicator by id - 미존재시 404`() {
+        every { indicatorService.getIndicatorById(999L) } throws NotFoundException("Indicator", 999L)
+
+        mockMvc.get("/api/indicators/999")
+            .andExpect {
+                status { isNotFound() }
+                jsonPath("$.success") { value(false) }
+                jsonPath("$.error.code") { value("NOT_FOUND") }
+            }
+    }
+
+    @Test
+    fun `GET categories - 전체 카테고리`() {
+        every { indicatorService.getCategories() } returns IndicatorCategory.entries.toList()
+
+        mockMvc.get("/api/indicators/categories")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.success") { value(true) }
+            }
+    }
+
+    @Test
+    fun `GET indicator data - 시계열 데이터`() {
+        val dataResponse = IndicatorDataResponse(
+            id = 1L,
+            indicatorId = 1L,
+            date = LocalDate.of(2025, 6, 1),
+            value = BigDecimal("5000.00"),
+            open = null,
+            high = null,
+            low = null,
+            close = null,
+            volume = null,
+            change = BigDecimal("1.5")
+        )
+        every { indicatorService.getIndicatorData(1L, any(), any(), any()) } returns
+            PageImpl(listOf(dataResponse), PageRequest.of(0, 100), 1)
+
+        mockMvc.get("/api/indicators/1/data?from=2025-01-01&to=2025-12-31")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.data.content[0].value") { value(5000.00) }
+            }
+    }
+
+    @Test
+    fun `POST series - 복수 지표 조회`() {
+        every { indicatorService.getMultipleIndicatorSeries(any()) } returns listOf(
+            IndicatorSeriesResponse(indicatorId = 1L, data = emptyList())
+        )
+
+        mockMvc.post("/api/indicators/series") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"indicatorIds":[1],"startDate":"2025-01-01","endDate":"2025-12-31"}"""
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.data[0].indicatorId") { value(1) }
+        }
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,8 @@ subprojects {
 
         "testImplementation"("org.springframework.boot:spring-boot-starter-test")
         "testImplementation"("org.jetbrains.kotlin:kotlin-test-junit5")
+        "testImplementation"("io.mockk:mockk:1.13.12")
+        "testImplementation"("com.ninja-squad:springmockk:4.0.2")
         "testRuntimeOnly"("org.junit.platform:junit-platform-launcher")
     }
 

--- a/core/src/main/kotlin/com/econdashboard/domain/AlertRule.kt
+++ b/core/src/main/kotlin/com/econdashboard/domain/AlertRule.kt
@@ -1,6 +1,7 @@
 package com.econdashboard.domain
 
 import com.econdashboard.enums.AlertConditionType
+import com.econdashboard.enums.AlertSeverity
 import jakarta.persistence.*
 import java.math.BigDecimal
 
@@ -20,6 +21,13 @@ class AlertRule(
 
     @Column(nullable = false, precision = 20, scale = 6)
     var threshold: BigDecimal,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    var severity: AlertSeverity = AlertSeverity.WARNING,
+
+    @Column(nullable = false, length = 500)
+    var message: String = "",
 
     @Column(nullable = false)
     var enabled: Boolean = true,

--- a/core/src/main/kotlin/com/econdashboard/dto/AlertDto.kt
+++ b/core/src/main/kotlin/com/econdashboard/dto/AlertDto.kt
@@ -3,6 +3,8 @@ package com.econdashboard.dto
 import com.econdashboard.domain.AlertHistory
 import com.econdashboard.domain.AlertRule
 import com.econdashboard.enums.AlertConditionType
+import com.econdashboard.enums.AlertSeverity
+import com.fasterxml.jackson.annotation.JsonProperty
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
 import java.math.BigDecimal
@@ -15,35 +17,64 @@ data class AlertRuleRequest(
     @field:NotNull(message = "지표 ID는 필수입니다")
     val indicatorId: Long,
 
-    @field:NotNull(message = "알림 조건 타입은 필수입니다")
-    val conditionType: AlertConditionType,
+    @field:NotNull(message = "알림 조건은 필수입니다")
+    val condition: String,
 
     @field:NotNull(message = "임계값은 필수입니다")
-    val threshold: BigDecimal
+    val threshold: BigDecimal,
+
+    val severity: String = "warning",
+
+    val message: String = ""
+) {
+    fun toConditionType(): AlertConditionType = when (condition) {
+        "above", "cross_above" -> AlertConditionType.ABOVE
+        "below", "cross_below" -> AlertConditionType.BELOW
+        "change_pct" -> AlertConditionType.CHANGE_PCT
+        else -> AlertConditionType.ABOVE
+    }
+
+    fun toSeverity(): AlertSeverity = AlertSeverity.fromValue(severity)
+}
+
+data class AlertRuleUpdateRequest(
+    val condition: String? = null,
+    val threshold: BigDecimal? = null,
+    val severity: String? = null,
+    val message: String? = null,
+    val enabled: Boolean? = null
 )
 
 data class AlertRuleResponse(
-    val id: Long,
-    val userId: String,
+    val id: String,
     val indicatorId: Long,
     val indicatorName: String,
-    val conditionType: AlertConditionType,
+    val condition: String,
     val threshold: BigDecimal,
+    val severity: String,
+    val message: String,
     val enabled: Boolean,
-    val createdAt: LocalDateTime,
-    val updatedAt: LocalDateTime
+    val createdAt: String,
+    val updatedAt: String? = null
 ) {
     companion object {
+        private fun conditionTypeToString(type: AlertConditionType): String = when (type) {
+            AlertConditionType.ABOVE -> "above"
+            AlertConditionType.BELOW -> "below"
+            AlertConditionType.CHANGE_PCT -> "change_pct"
+        }
+
         fun from(rule: AlertRule) = AlertRuleResponse(
-            id = rule.id,
-            userId = rule.userId,
+            id = rule.id.toString(),
             indicatorId = rule.indicator.id,
             indicatorName = rule.indicator.name,
-            conditionType = rule.conditionType,
+            condition = conditionTypeToString(rule.conditionType),
             threshold = rule.threshold,
+            severity = rule.severity.value,
+            message = rule.message,
             enabled = rule.enabled,
-            createdAt = rule.createdAt,
-            updatedAt = rule.updatedAt
+            createdAt = rule.createdAt.toString(),
+            updatedAt = rule.updatedAt.toString()
         )
     }
 }

--- a/core/src/main/kotlin/com/econdashboard/enums/AlertSeverity.kt
+++ b/core/src/main/kotlin/com/econdashboard/enums/AlertSeverity.kt
@@ -1,0 +1,14 @@
+package com.econdashboard.enums
+
+import com.fasterxml.jackson.annotation.JsonValue
+
+enum class AlertSeverity(@get:JsonValue val value: String) {
+    INFO("info"),
+    WARNING("warning"),
+    DANGER("danger");
+
+    companion object {
+        fun fromValue(value: String): AlertSeverity =
+            entries.firstOrNull { it.value == value } ?: WARNING
+    }
+}

--- a/infra/src/main/kotlin/com/econdashboard/service/AlertService.kt
+++ b/infra/src/main/kotlin/com/econdashboard/service/AlertService.kt
@@ -5,6 +5,7 @@ import com.econdashboard.domain.AlertRule
 import com.econdashboard.dto.AlertHistoryResponse
 import com.econdashboard.dto.AlertRuleRequest
 import com.econdashboard.dto.AlertRuleResponse
+import com.econdashboard.dto.AlertRuleUpdateRequest
 import com.econdashboard.enums.AlertConditionType
 import com.econdashboard.exception.NotFoundException
 import com.econdashboard.repository.AlertHistoryRepository
@@ -29,6 +30,10 @@ class AlertService(
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
+    fun getAlertRules(): List<AlertRuleResponse> {
+        return alertRuleRepository.findAll().map { AlertRuleResponse.from(it) }
+    }
+
     @Transactional
     fun createAlertRule(request: AlertRuleRequest): AlertRuleResponse {
         val indicator = indicatorRepository.findById(request.indicatorId)
@@ -37,10 +42,41 @@ class AlertService(
         val rule = AlertRule(
             userId = request.userId,
             indicator = indicator,
-            conditionType = request.conditionType,
-            threshold = request.threshold
+            conditionType = request.toConditionType(),
+            threshold = request.threshold,
+            severity = request.toSeverity(),
+            message = request.message
         )
         return AlertRuleResponse.from(alertRuleRepository.save(rule))
+    }
+
+    @Transactional
+    fun updateAlertRule(id: Long, request: AlertRuleUpdateRequest): AlertRuleResponse {
+        val rule = alertRuleRepository.findById(id)
+            .orElseThrow { NotFoundException("AlertRule", id) }
+
+        request.condition?.let {
+            rule.conditionType = when (it) {
+                "above", "cross_above" -> AlertConditionType.ABOVE
+                "below", "cross_below" -> AlertConditionType.BELOW
+                "change_pct" -> AlertConditionType.CHANGE_PCT
+                else -> rule.conditionType
+            }
+        }
+        request.threshold?.let { rule.threshold = it }
+        request.severity?.let { rule.severity = com.econdashboard.enums.AlertSeverity.fromValue(it) }
+        request.message?.let { rule.message = it }
+        request.enabled?.let { rule.enabled = it }
+
+        return AlertRuleResponse.from(alertRuleRepository.save(rule))
+    }
+
+    @Transactional
+    fun deleteAlertRule(id: Long) {
+        if (!alertRuleRepository.existsById(id)) {
+            throw NotFoundException("AlertRule", id)
+        }
+        alertRuleRepository.deleteById(id)
     }
 
     fun getAlertHistory(userId: String, pageable: Pageable): Page<AlertHistoryResponse> {

--- a/infra/src/main/resources/db/migration/V11__add_severity_message_to_alert_rules.sql
+++ b/infra/src/main/resources/db/migration/V11__add_severity_message_to_alert_rules.sql
@@ -1,0 +1,3 @@
+-- alert_rules에 severity, message 컬럼 추가 (프론트엔드 연동용)
+ALTER TABLE alert_rules ADD COLUMN severity VARCHAR(20) NOT NULL DEFAULT 'warning';
+ALTER TABLE alert_rules ADD COLUMN message VARCHAR(500) NOT NULL DEFAULT '';

--- a/infra/src/test/kotlin/com/econdashboard/service/AlertServiceTest.kt
+++ b/infra/src/test/kotlin/com/econdashboard/service/AlertServiceTest.kt
@@ -56,8 +56,10 @@ class AlertServiceTest {
         val request = AlertRuleRequest(
             userId = "user1",
             indicatorId = 1L,
-            conditionType = AlertConditionType.ABOVE,
-            threshold = BigDecimal("70000")
+            condition = "above",
+            threshold = BigDecimal("70000"),
+            severity = "warning",
+            message = "테스트 메시지"
         )
         every { indicatorRepository.findById(1L) } returns Optional.of(indicator)
         every { alertRuleRepository.save(any()) } answers {
@@ -70,8 +72,7 @@ class AlertServiceTest {
 
         val result = alertService.createAlertRule(request)
 
-        assertEquals("user1", result.userId)
-        assertEquals(AlertConditionType.ABOVE, result.conditionType)
+        assertEquals("above", result.condition)
         assertEquals(BigDecimal("70000"), result.threshold)
         verify { alertRuleRepository.save(any()) }
     }
@@ -81,7 +82,7 @@ class AlertServiceTest {
         val request = AlertRuleRequest(
             userId = "user1",
             indicatorId = 999L,
-            conditionType = AlertConditionType.ABOVE,
+            condition = "above",
             threshold = BigDecimal("70000")
         )
         every { indicatorRepository.findById(999L) } returns Optional.empty()

--- a/infra/src/test/kotlin/com/econdashboard/service/AlertServiceTest.kt
+++ b/infra/src/test/kotlin/com/econdashboard/service/AlertServiceTest.kt
@@ -1,0 +1,233 @@
+package com.econdashboard.service
+
+import com.econdashboard.domain.AlertHistory
+import com.econdashboard.domain.AlertRule
+import com.econdashboard.domain.Indicator
+import com.econdashboard.domain.IndicatorData
+import com.econdashboard.dto.AlertRuleRequest
+import com.econdashboard.enums.AlertConditionType
+import com.econdashboard.enums.DataSource
+import com.econdashboard.enums.IndicatorCategory
+import com.econdashboard.exception.NotFoundException
+import com.econdashboard.repository.AlertHistoryRepository
+import com.econdashboard.repository.AlertRuleRepository
+import com.econdashboard.repository.IndicatorDataRepository
+import com.econdashboard.repository.IndicatorRepository
+import io.mockk.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.*
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class AlertServiceTest {
+
+    private val alertRuleRepository: AlertRuleRepository = mockk()
+    private val alertHistoryRepository: AlertHistoryRepository = mockk()
+    private val indicatorRepository: IndicatorRepository = mockk()
+    private val indicatorDataRepository: IndicatorDataRepository = mockk()
+
+    private lateinit var alertService: AlertService
+    private lateinit var indicator: Indicator
+
+    @BeforeEach
+    fun setUp() {
+        alertService = AlertService(alertRuleRepository, alertHistoryRepository, indicatorRepository, indicatorDataRepository)
+        indicator = Indicator(
+            name = "비트코인",
+            symbol = "BTC-USD",
+            category = IndicatorCategory.CRYPTO,
+            unit = "USD",
+            source = DataSource.COINGECKO
+        ).apply {
+            val idField = Indicator::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, 1L)
+        }
+    }
+
+    @Test
+    fun `createAlertRule - 정상 생성`() {
+        val request = AlertRuleRequest(
+            userId = "user1",
+            indicatorId = 1L,
+            conditionType = AlertConditionType.ABOVE,
+            threshold = BigDecimal("70000")
+        )
+        every { indicatorRepository.findById(1L) } returns Optional.of(indicator)
+        every { alertRuleRepository.save(any()) } answers {
+            (firstArg() as AlertRule).apply {
+                val idField = AlertRule::class.java.getDeclaredField("id")
+                idField.isAccessible = true
+                idField.set(this, 1L)
+            }
+        }
+
+        val result = alertService.createAlertRule(request)
+
+        assertEquals("user1", result.userId)
+        assertEquals(AlertConditionType.ABOVE, result.conditionType)
+        assertEquals(BigDecimal("70000"), result.threshold)
+        verify { alertRuleRepository.save(any()) }
+    }
+
+    @Test
+    fun `createAlertRule - 존재하지 않는 지표`() {
+        val request = AlertRuleRequest(
+            userId = "user1",
+            indicatorId = 999L,
+            conditionType = AlertConditionType.ABOVE,
+            threshold = BigDecimal("70000")
+        )
+        every { indicatorRepository.findById(999L) } returns Optional.empty()
+
+        assertThrows<NotFoundException> {
+            alertService.createAlertRule(request)
+        }
+    }
+
+    @Test
+    fun `getAlertHistory - 사용자별 이력 조회`() {
+        val pageable = PageRequest.of(0, 20)
+        val rule = AlertRule(
+            userId = "user1",
+            indicator = indicator,
+            conditionType = AlertConditionType.ABOVE,
+            threshold = BigDecimal("70000")
+        ).apply {
+            val idField = AlertRule::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, 1L)
+        }
+        val history = AlertHistory(
+            userId = "user1",
+            indicator = indicator,
+            alertRule = rule,
+            conditionType = AlertConditionType.ABOVE,
+            threshold = BigDecimal("70000"),
+            actualValue = BigDecimal("71000"),
+            message = "비트코인이(가) 70000 이상에 도달했습니다."
+        ).apply {
+            val idField = AlertHistory::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, 1L)
+        }
+        every { alertHistoryRepository.findByUserIdOrderByCreatedAtDesc("user1", pageable) } returns PageImpl(listOf(history))
+
+        val result = alertService.getAlertHistory("user1", pageable)
+
+        assertEquals(1, result.totalElements)
+        assertEquals("user1", result.content[0].userId)
+    }
+
+    @Test
+    fun `checkAlerts - ABOVE 조건 트리거`() {
+        val rule = AlertRule(
+            userId = "user1",
+            indicator = indicator,
+            conditionType = AlertConditionType.ABOVE,
+            threshold = BigDecimal("70000")
+        ).apply {
+            val idField = AlertRule::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, 1L)
+        }
+        val latestData = IndicatorData(
+            indicator = indicator,
+            date = LocalDate.now(),
+            value = BigDecimal("71000")
+        )
+
+        every { alertRuleRepository.findByIndicatorIdAndEnabledTrue(1L) } returns listOf(rule)
+        every { indicatorDataRepository.findTopByIndicatorIdOrderByDateDesc(1L) } returns latestData
+        every { alertHistoryRepository.save(any()) } answers { firstArg() }
+
+        alertService.checkAlerts(1L)
+
+        verify { alertHistoryRepository.save(match { it.actualValue == BigDecimal("71000") }) }
+    }
+
+    @Test
+    fun `checkAlerts - BELOW 조건 미트리거`() {
+        val rule = AlertRule(
+            userId = "user1",
+            indicator = indicator,
+            conditionType = AlertConditionType.BELOW,
+            threshold = BigDecimal("60000")
+        ).apply {
+            val idField = AlertRule::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, 1L)
+        }
+        val latestData = IndicatorData(
+            indicator = indicator,
+            date = LocalDate.now(),
+            value = BigDecimal("65000")
+        )
+
+        every { alertRuleRepository.findByIndicatorIdAndEnabledTrue(1L) } returns listOf(rule)
+        every { indicatorDataRepository.findTopByIndicatorIdOrderByDateDesc(1L) } returns latestData
+
+        alertService.checkAlerts(1L)
+
+        verify(exactly = 0) { alertHistoryRepository.save(any()) }
+    }
+
+    @Test
+    fun `checkAlerts - CHANGE_PCT 조건 트리거`() {
+        val rule = AlertRule(
+            userId = "user1",
+            indicator = indicator,
+            conditionType = AlertConditionType.CHANGE_PCT,
+            threshold = BigDecimal("5")
+        ).apply {
+            val idField = AlertRule::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, 1L)
+        }
+        val latestData = IndicatorData(
+            indicator = indicator,
+            date = LocalDate.now(),
+            value = BigDecimal("71000"),
+            change = BigDecimal("7.5")
+        )
+
+        every { alertRuleRepository.findByIndicatorIdAndEnabledTrue(1L) } returns listOf(rule)
+        every { indicatorDataRepository.findTopByIndicatorIdOrderByDateDesc(1L) } returns latestData
+        every { alertHistoryRepository.save(any()) } answers { firstArg() }
+
+        alertService.checkAlerts(1L)
+
+        verify { alertHistoryRepository.save(any()) }
+    }
+
+    @Test
+    fun `checkAlerts - 규칙 없으면 아무것도 하지 않음`() {
+        every { alertRuleRepository.findByIndicatorIdAndEnabledTrue(1L) } returns emptyList()
+
+        alertService.checkAlerts(1L)
+
+        verify(exactly = 0) { indicatorDataRepository.findTopByIndicatorIdOrderByDateDesc(any()) }
+    }
+
+    @Test
+    fun `checkAlerts - 데이터 없으면 아무것도 하지 않음`() {
+        val rule = AlertRule(
+            userId = "user1",
+            indicator = indicator,
+            conditionType = AlertConditionType.ABOVE,
+            threshold = BigDecimal("70000")
+        )
+        every { alertRuleRepository.findByIndicatorIdAndEnabledTrue(1L) } returns listOf(rule)
+        every { indicatorDataRepository.findTopByIndicatorIdOrderByDateDesc(1L) } returns null
+
+        alertService.checkAlerts(1L)
+
+        verify(exactly = 0) { alertHistoryRepository.save(any()) }
+    }
+}

--- a/infra/src/test/kotlin/com/econdashboard/service/DashboardServiceTest.kt
+++ b/infra/src/test/kotlin/com/econdashboard/service/DashboardServiceTest.kt
@@ -1,0 +1,213 @@
+package com.econdashboard.service
+
+import com.econdashboard.domain.DashboardWidget
+import com.econdashboard.domain.Indicator
+import com.econdashboard.dto.DashboardWidgetRequest
+import com.econdashboard.enums.ChartType
+import com.econdashboard.enums.DataSource
+import com.econdashboard.enums.IndicatorCategory
+import com.econdashboard.exception.NotFoundException
+import com.econdashboard.repository.DashboardWidgetRepository
+import com.econdashboard.repository.IndicatorRepository
+import io.mockk.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.util.*
+import kotlin.test.assertEquals
+
+class DashboardServiceTest {
+
+    private val dashboardWidgetRepository: DashboardWidgetRepository = mockk()
+    private val indicatorRepository: IndicatorRepository = mockk()
+
+    private lateinit var dashboardService: DashboardService
+    private lateinit var indicator: Indicator
+
+    @BeforeEach
+    fun setUp() {
+        dashboardService = DashboardService(dashboardWidgetRepository, indicatorRepository)
+        indicator = Indicator(
+            name = "S&P 500",
+            symbol = "SPX",
+            category = IndicatorCategory.STOCK,
+            unit = "포인트",
+            source = DataSource.YAHOO
+        ).apply {
+            val idField = Indicator::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, 1L)
+        }
+    }
+
+    private fun createWidget(id: Long = 1L, title: String = "주가지수"): DashboardWidget {
+        return DashboardWidget(
+            title = title,
+            chartType = ChartType.LINE,
+            positionX = 0,
+            positionY = 0,
+            width = 2,
+            height = 1,
+            indicator = indicator
+        ).apply {
+            val idField = DashboardWidget::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, id)
+        }
+    }
+
+    @Test
+    fun `getAllWidgets - 위젯 목록 조회`() {
+        val widget = createWidget()
+        every { dashboardWidgetRepository.findAllByOrderByPositionYAscPositionXAsc() } returns listOf(widget)
+
+        val result = dashboardService.getAllWidgets()
+
+        assertEquals(1, result.size)
+        assertEquals("주가지수", result[0].title)
+        assertEquals(ChartType.LINE, result[0].chartType)
+    }
+
+    @Test
+    fun `createWidget - 정상 생성`() {
+        val request = DashboardWidgetRequest(
+            title = "비트코인",
+            chartType = ChartType.CANDLESTICK,
+            positionX = 0,
+            positionY = 0,
+            width = 2,
+            height = 1,
+            indicatorId = 1L
+        )
+        every { indicatorRepository.findById(1L) } returns Optional.of(indicator)
+        every { dashboardWidgetRepository.save(any()) } answers {
+            (firstArg() as DashboardWidget).apply {
+                val idField = DashboardWidget::class.java.getDeclaredField("id")
+                idField.isAccessible = true
+                idField.set(this, 1L)
+            }
+        }
+
+        val result = dashboardService.createWidget(request)
+
+        assertEquals("비트코인", result.title)
+        assertEquals(ChartType.CANDLESTICK, result.chartType)
+        assertEquals(1L, result.indicatorId)
+    }
+
+    @Test
+    fun `createWidget - indicatorId 없이 생성`() {
+        val request = DashboardWidgetRequest(
+            title = "뉴스 위젯",
+            chartType = ChartType.NUMBER,
+            positionX = 0,
+            positionY = 0,
+            width = 1,
+            height = 1
+        )
+        every { dashboardWidgetRepository.save(any()) } answers {
+            (firstArg() as DashboardWidget).apply {
+                val idField = DashboardWidget::class.java.getDeclaredField("id")
+                idField.isAccessible = true
+                idField.set(this, 2L)
+            }
+        }
+
+        val result = dashboardService.createWidget(request)
+
+        assertEquals("뉴스 위젯", result.title)
+        assertEquals(null, result.indicatorId)
+    }
+
+    @Test
+    fun `updateWidget - 정상 수정`() {
+        val widget = createWidget()
+        val request = DashboardWidgetRequest(
+            title = "수정된 위젯",
+            chartType = ChartType.BAR,
+            positionX = 1,
+            positionY = 1,
+            width = 3,
+            height = 2,
+            indicatorId = 1L
+        )
+
+        every { dashboardWidgetRepository.findById(1L) } returns Optional.of(widget)
+        every { indicatorRepository.findById(1L) } returns Optional.of(indicator)
+        every { dashboardWidgetRepository.save(any()) } answers { firstArg() }
+
+        val result = dashboardService.updateWidget(1L, request)
+
+        assertEquals("수정된 위젯", result.title)
+        assertEquals(ChartType.BAR, result.chartType)
+        assertEquals(3, result.width)
+    }
+
+    @Test
+    fun `updateWidget - 존재하지 않는 위젯`() {
+        every { dashboardWidgetRepository.findById(999L) } returns Optional.empty()
+
+        assertThrows<NotFoundException> {
+            dashboardService.updateWidget(999L, DashboardWidgetRequest(
+                title = "test", chartType = ChartType.LINE, positionX = 0, positionY = 0
+            ))
+        }
+    }
+
+    @Test
+    fun `deleteWidget - 정상 삭제`() {
+        every { dashboardWidgetRepository.existsById(1L) } returns true
+        every { dashboardWidgetRepository.deleteById(1L) } just runs
+
+        dashboardService.deleteWidget(1L)
+
+        verify { dashboardWidgetRepository.deleteById(1L) }
+    }
+
+    @Test
+    fun `deleteWidget - 존재하지 않는 위젯`() {
+        every { dashboardWidgetRepository.existsById(999L) } returns false
+
+        assertThrows<NotFoundException> {
+            dashboardService.deleteWidget(999L)
+        }
+    }
+
+    @Test
+    fun `saveWidgets - 일괄 저장`() {
+        val requests = listOf(
+            DashboardWidgetRequest(
+                title = "위젯1",
+                chartType = ChartType.LINE,
+                positionX = 0,
+                positionY = 0,
+                indicatorId = 1L
+            ),
+            DashboardWidgetRequest(
+                title = "위젯2",
+                chartType = ChartType.BAR,
+                positionX = 1,
+                positionY = 0
+            )
+        )
+
+        every { dashboardWidgetRepository.deleteAll() } just runs
+        every { indicatorRepository.findById(1L) } returns Optional.of(indicator)
+        every { dashboardWidgetRepository.saveAll(any<List<DashboardWidget>>()) } answers {
+            (firstArg() as List<DashboardWidget>).mapIndexed { idx, w ->
+                w.apply {
+                    val idField = DashboardWidget::class.java.getDeclaredField("id")
+                    idField.isAccessible = true
+                    idField.set(this, (idx + 1).toLong())
+                }
+            }
+        }
+
+        val result = dashboardService.saveWidgets(requests)
+
+        assertEquals(2, result.size)
+        assertEquals("위젯1", result[0].title)
+        assertEquals("위젯2", result[1].title)
+        verify { dashboardWidgetRepository.deleteAll() }
+    }
+}

--- a/infra/src/test/kotlin/com/econdashboard/service/IndicatorServiceTest.kt
+++ b/infra/src/test/kotlin/com/econdashboard/service/IndicatorServiceTest.kt
@@ -1,0 +1,177 @@
+package com.econdashboard.service
+
+import com.econdashboard.domain.Indicator
+import com.econdashboard.domain.IndicatorData
+import com.econdashboard.dto.IndicatorDataResponse
+import com.econdashboard.dto.IndicatorSeriesRequest
+import com.econdashboard.enums.DataSource
+import com.econdashboard.enums.IndicatorCategory
+import com.econdashboard.exception.NotFoundException
+import com.econdashboard.repository.IndicatorDataRepository
+import com.econdashboard.repository.IndicatorRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.*
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class IndicatorServiceTest {
+
+    private val indicatorRepository: IndicatorRepository = mockk()
+    private val indicatorDataRepository: IndicatorDataRepository = mockk()
+    private val indicatorCacheService: IndicatorCacheService = mockk()
+
+    private lateinit var indicatorService: IndicatorService
+
+    private lateinit var sampleIndicator: Indicator
+
+    @BeforeEach
+    fun setUp() {
+        indicatorService = IndicatorService(indicatorRepository, indicatorDataRepository, indicatorCacheService)
+        sampleIndicator = Indicator(
+            name = "S&P 500",
+            symbol = "SPX",
+            category = IndicatorCategory.STOCK,
+            unit = "포인트",
+            source = DataSource.YAHOO,
+            description = "미국 대표 주가지수"
+        ).apply {
+            // id는 JPA에서 자동 생성이지만 테스트용으로 reflection을 사용
+            val idField = Indicator::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, 1L)
+        }
+    }
+
+    @Test
+    fun `getAllIndicators - 카테고리 없이 전체 조회`() {
+        every { indicatorCacheService.findAllIndicators() } returns listOf(sampleIndicator)
+
+        val result = indicatorService.getAllIndicators(null)
+
+        assertEquals(1, result.size)
+        assertEquals("S&P 500", result[0].name)
+        assertEquals("SPX", result[0].symbol)
+        verify { indicatorCacheService.findAllIndicators() }
+    }
+
+    @Test
+    fun `getAllIndicators - 카테고리 필터`() {
+        every { indicatorCacheService.findByCategory(IndicatorCategory.STOCK) } returns listOf(sampleIndicator)
+
+        val result = indicatorService.getAllIndicators(IndicatorCategory.STOCK)
+
+        assertEquals(1, result.size)
+        verify { indicatorCacheService.findByCategory(IndicatorCategory.STOCK) }
+    }
+
+    @Test
+    fun `getIndicatorById - 정상 조회`() {
+        every { indicatorRepository.findById(1L) } returns Optional.of(sampleIndicator)
+
+        val result = indicatorService.getIndicatorById(1L)
+
+        assertEquals(1L, result.id)
+        assertEquals("S&P 500", result.name)
+    }
+
+    @Test
+    fun `getIndicatorById - 존재하지 않는 지표`() {
+        every { indicatorRepository.findById(999L) } returns Optional.empty()
+
+        assertThrows<NotFoundException> {
+            indicatorService.getIndicatorById(999L)
+        }
+    }
+
+    @Test
+    fun `getCategories - 전체 카테고리 반환`() {
+        val result = indicatorService.getCategories()
+
+        assertEquals(IndicatorCategory.entries.size, result.size)
+    }
+
+    @Test
+    fun `getIndicatorData - 날짜 범위로 시계열 데이터 조회`() {
+        val pageable = PageRequest.of(0, 100)
+        val indicatorData = IndicatorData(
+            indicator = sampleIndicator,
+            date = LocalDate.of(2025, 1, 15),
+            value = BigDecimal("5000.00")
+        ).apply {
+            val idField = IndicatorData::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, 1L)
+        }
+        val page = PageImpl(listOf(indicatorData), pageable, 1)
+
+        every { indicatorRepository.findById(1L) } returns Optional.of(sampleIndicator)
+        every {
+            indicatorDataRepository.findByIndicatorIdAndDateBetweenOrderByDateAsc(
+                1L, any(), any(), pageable
+            )
+        } returns page
+
+        val result = indicatorService.getIndicatorData(
+            1L, LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31), pageable
+        )
+
+        assertEquals(1, result.totalElements)
+        assertEquals(BigDecimal("5000.00"), result.content[0].value)
+    }
+
+    @Test
+    fun `getIndicatorData - 날짜 미지정시 기본값 적용`() {
+        val pageable = PageRequest.of(0, 100)
+        val page = PageImpl<IndicatorData>(emptyList(), pageable, 0)
+
+        every { indicatorRepository.findById(1L) } returns Optional.of(sampleIndicator)
+        every {
+            indicatorDataRepository.findByIndicatorIdAndDateBetweenOrderByDateAsc(
+                1L, any(), any(), pageable
+            )
+        } returns page
+
+        val result = indicatorService.getIndicatorData(1L, null, null, pageable)
+
+        assertNotNull(result)
+    }
+
+    @Test
+    fun `getMultipleIndicatorSeries - 복수 지표 시계열 조회`() {
+        val indicatorData = IndicatorData(
+            indicator = sampleIndicator,
+            date = LocalDate.of(2025, 6, 1),
+            value = BigDecimal("5200.00")
+        ).apply {
+            val idField = IndicatorData::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, 1L)
+        }
+
+        every { indicatorRepository.findById(1L) } returns Optional.of(sampleIndicator)
+        every {
+            indicatorCacheService.findSeriesData(1L, any(), any())
+        } returns listOf(indicatorData)
+
+        val request = IndicatorSeriesRequest(
+            indicatorIds = listOf(1L),
+            startDate = LocalDate.of(2025, 1, 1),
+            endDate = LocalDate.of(2025, 12, 31)
+        )
+
+        val result = indicatorService.getMultipleIndicatorSeries(request)
+
+        assertEquals(1, result.size)
+        assertEquals(1L, result[0].indicatorId)
+        assertEquals(1, result[0].data.size)
+    }
+}

--- a/infra/src/test/kotlin/com/econdashboard/service/SubscriptionServiceTest.kt
+++ b/infra/src/test/kotlin/com/econdashboard/service/SubscriptionServiceTest.kt
@@ -1,0 +1,125 @@
+package com.econdashboard.service
+
+import com.econdashboard.domain.Indicator
+import com.econdashboard.domain.Subscription
+import com.econdashboard.dto.SubscriptionRequest
+import com.econdashboard.enums.DataSource
+import com.econdashboard.enums.IndicatorCategory
+import com.econdashboard.exception.BusinessException
+import com.econdashboard.exception.NotFoundException
+import com.econdashboard.repository.IndicatorRepository
+import com.econdashboard.repository.SubscriptionRepository
+import io.mockk.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.util.*
+import kotlin.test.assertEquals
+
+class SubscriptionServiceTest {
+
+    private val subscriptionRepository: SubscriptionRepository = mockk()
+    private val indicatorRepository: IndicatorRepository = mockk()
+
+    private lateinit var subscriptionService: SubscriptionService
+    private lateinit var indicator: Indicator
+
+    @BeforeEach
+    fun setUp() {
+        subscriptionService = SubscriptionService(subscriptionRepository, indicatorRepository)
+        indicator = Indicator(
+            name = "S&P 500",
+            symbol = "SPX",
+            category = IndicatorCategory.STOCK,
+            unit = "포인트",
+            source = DataSource.YAHOO
+        ).apply {
+            val idField = Indicator::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, 1L)
+        }
+    }
+
+    @Test
+    fun `getSubscriptions - 사용자 구독 목록 조회`() {
+        val subscription = Subscription(
+            userId = "user1",
+            indicator = indicator
+        ).apply {
+            val idField = Subscription::class.java.getDeclaredField("id")
+            idField.isAccessible = true
+            idField.set(this, 1L)
+        }
+
+        every { subscriptionRepository.findByUserId("user1") } returns listOf(subscription)
+
+        val result = subscriptionService.getSubscriptions("user1")
+
+        assertEquals(1, result.size)
+        assertEquals("user1", result[0].userId)
+        assertEquals("SPX", result[0].indicatorSymbol)
+    }
+
+    @Test
+    fun `subscribe - 정상 구독`() {
+        val request = SubscriptionRequest(userId = "user1", indicatorId = 1L)
+
+        every { subscriptionRepository.existsByUserIdAndIndicatorId("user1", 1L) } returns false
+        every { indicatorRepository.findById(1L) } returns Optional.of(indicator)
+        every { subscriptionRepository.save(any()) } answers {
+            (firstArg() as Subscription).apply {
+                val idField = Subscription::class.java.getDeclaredField("id")
+                idField.isAccessible = true
+                idField.set(this, 1L)
+            }
+        }
+
+        val result = subscriptionService.subscribe(request)
+
+        assertEquals("user1", result.userId)
+        assertEquals(1L, result.indicatorId)
+    }
+
+    @Test
+    fun `subscribe - 이미 구독 중인 경우`() {
+        val request = SubscriptionRequest(userId = "user1", indicatorId = 1L)
+
+        every { subscriptionRepository.existsByUserIdAndIndicatorId("user1", 1L) } returns true
+
+        val ex = assertThrows<BusinessException> {
+            subscriptionService.subscribe(request)
+        }
+        assertEquals("ALREADY_SUBSCRIBED", ex.errorCode)
+    }
+
+    @Test
+    fun `subscribe - 존재하지 않는 지표`() {
+        val request = SubscriptionRequest(userId = "user1", indicatorId = 999L)
+
+        every { subscriptionRepository.existsByUserIdAndIndicatorId("user1", 999L) } returns false
+        every { indicatorRepository.findById(999L) } returns Optional.empty()
+
+        assertThrows<NotFoundException> {
+            subscriptionService.subscribe(request)
+        }
+    }
+
+    @Test
+    fun `unsubscribe - 정상 삭제`() {
+        every { subscriptionRepository.existsById(1L) } returns true
+        every { subscriptionRepository.deleteById(1L) } just runs
+
+        subscriptionService.unsubscribe(1L)
+
+        verify { subscriptionRepository.deleteById(1L) }
+    }
+
+    @Test
+    fun `unsubscribe - 존재하지 않는 구독`() {
+        every { subscriptionRepository.existsById(999L) } returns false
+
+        assertThrows<NotFoundException> {
+            subscriptionService.unsubscribe(999L)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `GET /api/alerts/rules` 엔드포인트 추가 — 500 Internal Server Error 수정
- `PUT /api/alerts/rules/{id}`, `DELETE /api/alerts/rules/{id}` 엔드포인트 추가
- 프론트엔드 스키마에 맞게 응답 DTO 정렬 (conditionType→condition, severity/message 필드 추가)
- DB 마이그레이션 V11: alert_rules 테이블에 severity, message 컬럼 추가

## Test plan
- [x] AlertControllerTest — GET/POST 규칙 조회/생성 테스트 통과
- [x] AlertServiceTest — 생성/이력/알림 체크 테스트 통과
- [ ] QA 환경에서 `/api/alerts/rules` 정상 200 응답 확인
- [ ] 프론트엔드 AlertPanel에서 규칙 CRUD 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)